### PR TITLE
chore: fix publish to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/
@@ -21,7 +21,7 @@ jobs:
       - run: npm install -g npm@latest
       - run: npm i
       - run: npm test
-      - run: npm version ${TAG_NAME} --git-tag-version=false
+      - run: npm version ${TAG_NAME} --git-tag-version=false -w vue-esm-loader
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
       - run: npm whoami; npm publish -w vue-esm-loader --provenance --access public


### PR DESCRIPTION
Our publish to npm script was broken because we're now using workspaces. Should be fixed now.